### PR TITLE
Update GitHub Actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,14 +27,14 @@ jobs:
           "
 
     - name: Upload pdf as an artifact
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: Cyphal Specification
         path: specification/Cyphal_Specification.pdf
         if-no-files-found: error
 
     - name: Upload diagnostic snapshot
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       if: always()
       with:
         name: workspace-${{github.job}}


### PR DESCRIPTION
actions/upload-artifact@v3 was deprecated on 2025-01-03 in favour of v4: https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/
